### PR TITLE
English name coalesce

### DIFF
--- a/layers/aerodrome_label/layer.sql
+++ b/layers/aerodrome_label/layer.sql
@@ -22,7 +22,7 @@ $$
     osm_id,
     geometry,
     name,
-    COALESCE(NULLIF(name_en, ''), name) AS name_en,
+    COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
     tags,
     CASE
       %%FIELD_MAPPING: class %%

--- a/layers/mountain_peak/layer.sql
+++ b/layers/mountain_peak/layer.sql
@@ -29,7 +29,7 @@ $$
     ele_ft::int, 
     rank::int FROM (
       SELECT osm_id, geometry, name,
-      COALESCE(NULLIF(name_en, ''), name) AS name_en,
+      COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
       tags,
       substring(ele from E'^(-?\\d+)(\\D|$)')::int AS ele,
       round(substring(ele from E'^(-?\\d+)(\\D|$)')::int*3.2808399)::int AS ele_ft,

--- a/layers/place/city.sql
+++ b/layers/place/city.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE FUNCTION layer_city(bbox geometry, zoom_level int, pixel_width
 RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, tags hstore, place city_place, "rank" int, capital int) AS $$
   SELECT * FROM (
     SELECT osm_id, geometry, name,
-    COALESCE(NULLIF(name_en, ''), name) AS name_en,
+    COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
     tags,
     place, "rank", normalize_capital_level(capital) AS capital
     FROM osm_city_point
@@ -17,14 +17,14 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, tags hs
       )
     UNION ALL
     SELECT osm_id, geometry, name,
-        COALESCE(NULLIF(name_en, ''), name) AS name_en,
+        COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
         tags,
         place,
         COALESCE("rank", gridrank + 10),
         normalize_capital_level(capital) AS capital
     FROM (
       SELECT osm_id, geometry, name,
-      COALESCE(NULLIF(name_en, ''), name) AS name_en,
+      COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
       tags,
       place, "rank", capital,
       row_number() OVER (

--- a/layers/place/layer.sql
+++ b/layers/place/layer.sql
@@ -55,7 +55,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text,
     -- etldoc: osm_island_point    -> layer_place:z12_14
     SELECT
         osm_id*10, geometry, name,
-        COALESCE(NULLIF(name_en, ''), name) AS name_en,
+        COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
         tags,
         'island' AS class, 7 AS "rank", NULL::int AS capital,
         NULL::text AS iso_a2
@@ -68,7 +68,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text,
     -- etldoc: osm_island_polygon  -> layer_place:z12_14
     SELECT
         osm_id*10, geometry, name,
-        COALESCE(NULLIF(name_en, ''), name) AS name_en,
+        COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
         tags,
         'island' AS class, island_rank(area) AS "rank", NULL::int AS capital,
         NULL::text AS iso_a2

--- a/layers/place/update_city_point.sql
+++ b/layers/place/update_city_point.sql
@@ -50,6 +50,9 @@ $$ LANGUAGE plpgsql;
 
 SELECT update_osm_city_point();
 
+-- delete zero-length english names
+update osm_city_point set name_en = null where length(name_en) = 0;
+
 CREATE INDEX IF NOT EXISTS osm_city_point_rank_idx ON osm_city_point("rank");
 
 -- Handle updates

--- a/layers/poi/layer.sql
+++ b/layers/poi/layer.sql
@@ -5,7 +5,7 @@
 CREATE OR REPLACE FUNCTION layer_poi(bbox geometry, zoom_level integer, pixel_width numeric)
 RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, tags hstore, class text, subclass text, agg_stop integer, layer integer, level integer, indoor integer, "rank" int) AS $$
     SELECT osm_id_hash AS osm_id, geometry, NULLIF(name, '') AS name,
-        COALESCE(NULLIF(name_en, ''), name) AS name_en,
+        COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
         tags,
         poi_class(subclass, mapping_key) AS class,
         CASE

--- a/layers/transportation_name/layer.sql
+++ b/layers/transportation_name/layer.sql
@@ -8,7 +8,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text,
   text, subclass text, layer INT, level INT, indoor INT) AS $$
     SELECT osm_id, geometry,
       NULLIF(name, '') AS name,
-      COALESCE(NULLIF(name_en, ''), name) AS name_en,
+      COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
       tags,
       NULLIF(ref, ''), NULLIF(LENGTH(ref), 0) AS ref_length,
       --TODO: The road network of the road is not yet implemented

--- a/layers/transportation_name/update_transportation_name.sql
+++ b/layers/transportation_name/update_transportation_name.sql
@@ -1,6 +1,8 @@
 DROP TRIGGER IF EXISTS trigger_flag_transportation_name ON osm_highway_linestring;
 DROP TRIGGER IF EXISTS trigger_refresh ON transportation_name.updates;
 
+update osm_highway_linestring set name_en = null where length(name_en) = 0;
+
 -- Instead of using relations to find out the road names we
 -- stitch together the touching ways with the same name
 -- to allow for nice label rendering

--- a/layers/water_name/layer.sql
+++ b/layers/water_name/layer.sql
@@ -11,7 +11,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, tags hs
         ELSE osm_id*10+1
     END AS osm_id_hash,
     geometry, name,
-    COALESCE(NULLIF(name_en, ''), name) AS name_en,
+    COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
     tags,
     'lake'::text AS class,
     is_intermittent::int AS intermittent
@@ -41,7 +41,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, tags hs
     -- etldoc: osm_marine_point ->  layer_water_name:z14_
     UNION ALL
     SELECT osm_id*10, geometry, name,
-    COALESCE(NULLIF(name_en, ''), name) AS name_en,
+    COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
     tags,
     place::text AS class,
     is_intermittent::int AS intermittent

--- a/layers/water_name/layer.sql
+++ b/layers/water_name/layer.sql
@@ -27,7 +27,7 @@ RETURNS TABLE(osm_id bigint, geometry geometry, name text, name_en text, tags hs
         ELSE osm_id*10+1
     END AS osm_id_hash,
     geometry, name,
-    COALESCE(NULLIF(name_en, ''), name) AS name_en,
+    COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
     tags,
     'lake'::text AS class,
     is_intermittent::int AS intermittent

--- a/layers/waterway/waterway.sql
+++ b/layers/waterway/waterway.sql
@@ -65,7 +65,7 @@ CREATE OR REPLACE FUNCTION layer_waterway(bbox geometry, zoom_level int)
 RETURNS TABLE(geometry geometry, class text, name text, name_en text, brunnel text, intermittent int, tags hstore) AS $$
     SELECT geometry, class,
         NULLIF(name, '') AS name,
-        COALESCE(NULLIF(name_en, ''), name) AS name_en,
+        COALESCE(NULLIF(name_en, ''), tags->'name:latin', name) AS name_en,
         waterway_brunnel(is_bridge, is_tunnel) AS brunnel,
         is_intermittent::int AS intermittent,
         tags


### PR DESCRIPTION
Sometimes name:en isn't available but name:latin is, and is pretty close to the English name, in countries with different scripts (China, Russia, etc...). So first fallback on name:latin before name.